### PR TITLE
Update from Slack username to id

### DIFF
--- a/incoming/function.js
+++ b/incoming/function.js
@@ -151,11 +151,12 @@ incoming.fn = function(event, context, callback) {
               });
               return callback(lambdaFailure);
             }
+
             console.log({
               severity: 'info',
               requestId: requestId,
               service: 'lambda',
-              message: `broadcast routing success - opened GitHub issue ${status.url}`
+              message: `broadcast routing success - opened GitHub issue ${status[0].url}`
             });
             return callback(null, lambdaSuccess);
           });
@@ -246,7 +247,7 @@ incoming.checkEvent = function(event, callback) {
 incoming.checkUser = function(user, gitHubDefaultUser, slackDefaultChannel) {
   if (!user.slackId) {
     // missing Slack ID, fallback to default channel
-    user.slack = `#${slackDefaultChannel}`;
+    user.slackId = `#${slackDefaultChannel}`;
   }
   if (!user.github) {
     // missing GitHub handle, fallback to default user/team
@@ -274,11 +275,19 @@ incoming.callGitHub = function(user, message, requestId, gitHubOwner, gitHubRepo
     title: message.body.github.title
   };
 
-  if (message.users.length > 1) {
-    // if broadcast to >1 users, compile list of Slack IDs that were sent the message
-    let userArray = message.users.map(function(obj) { return obj.slack; });
+  // BROADCAST
+  if (message.type === 'broadcast') {
+    // if broadcast to >1 users, compile list of recipient Slack display_names or IDs
+    let userArray = message.users.map(function(obj) {
+      if (obj.slack) return obj.slack;
+      else return obj.slackId;
+    });
+    // add recipient list wrapped in GitHub MD code tags
     options.body = `${message.body.github.body} \n\n \`\`\`\n${userArray.toString()}\n\`\`\``;
-  } else {
+  }
+
+  // SELF-SERVICE
+  if (message.type === 'self-service') {
     options.body = `${message.body.github.body} \n\n @${user.github}`;
   }
 
@@ -321,9 +330,11 @@ incoming.callPagerDuty = function(message, requestId, pagerDutyApiKey, pagerDuty
 /**
  * Trigger lib/slack.js functionality, send Slack message for dispatch alert
  *
+ * @param {object} user - user object, contains Slack ID (destination)
  * @param {object} message - message object, contains Slack message body and interactive options
  * @param {string} requestId - unique ID per dispatch alert
  * @param {string} slackDefaultChannel - passed again as a fallback for issue with Slack username
+ * @param {object} resGitHub - response object from callGitHub
  * @param {string} slackBotToken
  * @param {function} callback
  */

--- a/incoming/function.js
+++ b/incoming/function.js
@@ -244,11 +244,7 @@ incoming.checkEvent = function(event, callback) {
  * @param {string} slackDefaultChannel - default Slack channel, substitute if user.slack is missing
  */
 incoming.checkUser = function(user, gitHubDefaultUser, slackDefaultChannel) {
-  if (user.slack && !(user.slack.indexOf('@') > -1)) {
-    // user has Slack ID
-    user.slack = `@${user.slack}`;
-  }
-  if (!user.slack) {
+  if (!user.slackId) {
     // missing Slack ID, fallback to default channel
     user.slack = `#${slackDefaultChannel}`;
   }
@@ -281,7 +277,7 @@ incoming.callGitHub = function(user, message, requestId, gitHubOwner, gitHubRepo
   if (message.users.length > 1) {
     // if broadcast to >1 users, compile list of Slack IDs that were sent the message
     let userArray = message.users.map(function(obj) { return obj.slack; });
-    options.body = `${message.body.github.body} \n\n ${userArray.toString()}`;
+    options.body = `${message.body.github.body} \n\n \`\`\`\n${userArray.toString()}\n\`\`\``;
   } else {
     options.body = `${message.body.github.body} \n\n @${user.github}`;
   }
@@ -338,7 +334,7 @@ incoming.callSlack = function(user, message, requestId, slackDefaultChannel, sla
   message.number = resGitHub.number;
   message.requestId = requestId;
 
-  slack.alertToSlack(message, user.slack, client, slackDefaultChannel, (err, status) => {
+  slack.alertToSlack(message, user.slackId, client, slackDefaultChannel, (err, status) => {
     if (err) return callback(err);
     return callback(null, status);
   });

--- a/lib/slack.js
+++ b/lib/slack.js
@@ -141,7 +141,7 @@ slack.postAlert = function(destination, message, client, slackChannel, requestId
         severity: 'error',
         requestId: requestId,
         service: 'slack',
-        message: err
+        message: `${err} for destination ${destination}`
       });
 
       // log error to default SlackChannel for visibility
@@ -156,7 +156,7 @@ slack.postAlert = function(destination, message, client, slackChannel, requestId
       };
 
       client.chat.postMessage(slackChannel, postFailure.text, { attachments: postFailure.attachments }, (err, res) => {
-        if (err) return callback(err, res);
+        if (err) return callback(`${err} for destination ${slackChannel}`, res);
         return callback(null, res);
       });
     } else {

--- a/lib/slack.js
+++ b/lib/slack.js
@@ -126,13 +126,12 @@ slack.postAlert = function(destination, message, client, slackChannel, requestId
 
   let options;
 
-  if (destination.indexOf('@') > -1) {
-    // destination is a user
-    options = { 'as_user': true, attachments: message.attachments };
-  }
   if (destination.indexOf('#') > -1) {
     // destination is a channel
     options = { attachments: message.attachments };
+  } else {
+    // destination is a user
+    options = { 'as_user': true, attachments: message.attachments };
   }
 
   client.chat.postMessage(destination, message.text, options, (err, res) => {

--- a/test/fixtures/github.fixtures.js
+++ b/test/fixtures/github.fixtures.js
@@ -25,7 +25,7 @@ module.exports.broadcastIssue = {
   created_at: '2017-08-02T23:36:11Z',
   updated_at: '2017-08-02T23:36:11Z',
   closed_at: null,
-  body: 'testGithubBody\n\n @testGitHubUser'
+  body: 'testGithubBody\n\n testSlackID'
 };
 
 module.exports.selfServiceIssue = {

--- a/test/fixtures/incoming.fixtures.js
+++ b/test/fixtures/incoming.fixtures.js
@@ -7,7 +7,7 @@ module.exports.missingPriorityEvent = {
       Sns: {
         Message: JSON.stringify(
           {
-            users: [ { github: 'testGitHubUser', slack: 'testSlackUser' }],
+            users: [ { github: 'testGitHubUser', slack: 'testSlackUser', slackId: 'testSlackId' }],
             body: {
               github: {
                 title: 'testGitHubTitle',
@@ -38,13 +38,16 @@ module.exports.broadcastEvent = {
             type: 'broadcast',
             users: [
               {
-                slack: 'testSlackUser1'
+                slack: 'testSlackUser1',
+                slackId: 'testSlackId1'
               },
               {
-                slack: 'testSlackUser2'
+                slack: 'testSlackUser2',
+                slackId: 'testSlackId2'
               },
               {
-                slack: 'testSlackUser3'
+                slack: 'testSlackUser3',
+                slackId: 'testSlackId3'
               }
             ],
             body: {
@@ -108,7 +111,7 @@ module.exports.selfServiceEvent = {
         Message: JSON.stringify(
           {
             type: 'self-service',
-            users: [ { github: 'testGitHubUser', slack: 'testSlackUser' }],
+            users: [ { github: 'testGitHubUser', slack: 'testSlackUser', slackId: 'testSlackId' }],
             body: {
               github: {
                 title: 'testGitHubTitle',
@@ -133,11 +136,11 @@ module.exports.selfServiceEvent = {
 };
 
 module.exports.userMissingGitHub = {
-  slack: '@testSlackUsername'
+  slackId: 'testSlackId'
 };
 
 module.exports.userDefautGitHub = {
-  slack: '@testSlackUsername',
+  slackId: 'testSlackId',
   github: 'testGitHubDefaultUser'
 };
 

--- a/test/fixtures/incoming.fixtures.js
+++ b/test/fixtures/incoming.fixtures.js
@@ -135,6 +135,41 @@ module.exports.selfServiceEvent = {
   ]
 };
 
+module.exports.callGitHubEvent = {
+  user: 'testGitHubDefaultUser',
+  requestId: 'testRequestId',
+  messageBroadcastError: {
+    type: 'broadcast',
+    users: [
+      {
+        slackId: 'testSlackDefaultChannel'
+      },
+      {
+        slack: 'testSlackUser2',
+        slackId: 'testSlackId2'
+      },
+      {
+        slack: 'testSlackUser3',
+        slackId: 'testSlackId3'
+      }
+    ],
+    body: {
+      github: {
+        title: 'testGithubTitle',
+        body: 'testGithubBody'
+      }
+    }
+  },
+  res: {
+    owner: 'testGitHubOwner',
+    repo: 'testGitHubRepo',
+    title: 'testGithubTitle',
+    body: 'testGithubBody \n\n ```\ntestSlackDefaultChannel,testSlackUser2,testSlackUser3\n```',
+    number: 7,
+    url: 'https://github.com/testGitHubOwner/testGitHubRepo/issues/7'
+  }
+};
+
 module.exports.userMissingGitHub = {
   slackId: 'testSlackId'
 };
@@ -150,7 +185,7 @@ module.exports.userMissingSlack = {
 
 module.exports.userDefautSlack = {
   github: 'testGitHubUsername',
-  slack: '#testSlackDefaultChannel'
+  slackId: '#testSlackDefaultChannel'
 };
 
 module.exports.malformedSNS = {

--- a/test/fixtures/slack.fixtures.js
+++ b/test/fixtures/slack.fixtures.js
@@ -161,6 +161,7 @@ module.exports.slack = {
     scopes: [ 'identify', 'bot:basic' ],
     acceptedScopes: [ 'chat:write:bot', 'post' ]
   },
+  errorNoChannelFallback: 'channel_not_found for destination #testSlackDefaultChannel',
   message: {
     text: 'testSlackMessage',
     attachments: [

--- a/test/fixtures/slack.fixtures.js
+++ b/test/fixtures/slack.fixtures.js
@@ -3,7 +3,20 @@
 module.exports.sns = {
   broadcast: {
     type: 'broadcast',
-    users: ['@testSlackUser1', '@testSlackUser2', '@testSlackUser3'],
+    users: [
+      {
+        slack: 'testSlackUser1',
+        slackId: 'testSlackId1'
+      },
+      {
+        slack: 'testSlackUser2',
+        slackId: 'testSlackId2'
+      },
+      {
+        slack: 'testSlackUser3',
+        slackId: 'testSlackId3'
+      }
+    ],
     callback_id: 'testCallbackId',
     body: {
       github: {
@@ -20,7 +33,12 @@ module.exports.sns = {
   },
   encode: {
     type: 'self-service',
-    users: ['@testSlackUser'],
+    users: [
+      {
+        slack: 'testSlackUser',
+        slackId: 'testSlackId'
+      }
+    ],
     body: {
       github: {
         title: 'testGitHubTitle',
@@ -41,7 +59,12 @@ module.exports.sns = {
   encodeError: 'Error - dispatch testRequestId message body missing GitHub issue number',
   malformed: {
     type: 'self-service',
-    users: ['@testSlackUser'],
+    users: [
+      {
+        slack: 'testSlackUser',
+        slackId: 'testSlackId'
+      }
+    ],
     body: {},
     number: 7,
     url: 'https://github.com/testGitHubOwner/testGitHubRepo/issues/7',
@@ -51,7 +74,12 @@ module.exports.sns = {
   requestId: 'testRequestId',
   success: {
     type: 'self-service',
-    users: ['@testSlackUser'],
+    users: [
+      {
+        slack: 'testSlackUser',
+        slackId: 'testSlackId'
+      }
+    ],
     callback_id: 'testCallbackId',
     body: {
       github: {
@@ -73,7 +101,12 @@ module.exports.sns = {
   },
   successWithResponse: {
     type: 'self-service',
-    users: ['@testSlackUser'],
+    users: [
+      {
+        slack: 'testSlackUser',
+        slackId: 'testSlackId'
+      }
+    ],
     callback_id: 'testCallbackId',
     body: {
       github: {
@@ -97,7 +130,12 @@ module.exports.sns = {
   },
   successNoPrompt: {
     type: 'self-service',
-    users: ['@testSlackUser'],
+    users: [
+      {
+        slack: 'testSlackUser',
+        slackId: 'testSlackId'
+      }
+    ],
     'callback_id': 'testCallbackId',
     number: 7,
     body: {
@@ -200,39 +238,39 @@ module.exports.slack = {
   },
   status: {
     alert: true,
-    destination: '@testSlackUser',
+    destination: 'testSlackId',
     message: 'testSlackMessage',
     url: 'https://github.com/testGitHubOwner/testGitHubRepo/issues/7'
   },
   statusBroadcast: [
     {
       alert: true,
-      destination: '@testSlackUser1',
+      destination: 'testSlackId1',
       message: 'testSlackMessage',
       url: 'https://github.com/testGitHubOwner/testGitHubRepo/issues/7'
     },
     {
       alert: true,
-      destination: '@testSlackUser2',
+      destination: 'testSlackId2',
       message: 'testSlackMessage',
       url: 'https://github.com/testGitHubOwner/testGitHubRepo/issues/7'
     },
     {
       alert: true,
-      destination: '@testSlackUser3',
+      destination: 'testSlackId3',
       message: 'testSlackMessage',
       url: 'https://github.com/testGitHubOwner/testGitHubRepo/issues/7'
     }
   ],
   statusIncomingSelfService: {
     alert: true,
-    destination: '@testSlackUser',
+    destination: 'testSlackId',
     message: 'testSlackMessage',
     url: 'https://github.com/testGitHubOwner/testGitHubRepo/issues/7'
   },
   statusPrompt: {
     alert: true,
-    destination: '@testSlackUser',
+    destination: 'testSlackId',
     message: 'testSlackMessage, Prompt: testSlackPrompt',
     url: 'https://github.com/testGitHubOwner/testGitHubRepo/issues/7'
   },
@@ -279,8 +317,7 @@ module.exports.slack = {
     scopes: [ 'identify', 'bot:basic' ],
     acceptedScopes: [ 'chat:write:user', 'client' ]
   },
-  username: '@testSlackUser',
-  usernameBroadcast: '@testSlackUser1'
+  slackId: 'testSlackId'
 };
 
 module.exports.clients = {
@@ -293,8 +330,8 @@ module.exports.clients = {
     _token:'testSlackBotToken',
     slackAPIUrl:'testSlackApiUrl',
     chat: {
-      postMessage: function(username, message, options, callback) {
-        if (username == '@testSlackUser') {
+      postMessage: function(destination, message, options, callback) {
+        if (destination == 'testSlackId') {
           return callback('channel_not_found', {
             ok: false,
             error: 'channel_not_found',
@@ -325,8 +362,8 @@ module.exports.clients = {
     _token:'testSlackBotToken',
     slackAPIUrl:'testSlackApiUrl',
     chat: {
-      postMessage: function(username, message, options, callback) {
-        if (username == '@testSlackUser') {
+      postMessage: function(destination, message, options, callback) {
+        if (destination == 'testSlackId') {
           return callback('channel_not_found', {
             ok: false,
             error: 'channel_not_found',
@@ -348,7 +385,7 @@ module.exports.clients = {
     _token:'testSlackBotToken',
     slackAPIUrl:'testSlackApiUrl',
     chat: {
-      postMessage: function(username, message, options, callback) {
+      postMessage: function(destination, message, options, callback) {
         return callback(null, {
           ok: true,
           channel: 'D6G0UU7MW',

--- a/test/lib/slack.test.js
+++ b/test/lib/slack.test.js
@@ -40,14 +40,14 @@ test('[slack] [formatMessage] broadcast success', (assert) => {
 });
 
 test('[slack] [postAlert] missing message body error', (assert) => {
-  slack.postAlert(fixtures.slack.username, fixtures.slack.missingMessage, fixtures.clients.empty, fixtures.slack.channel, fixtures.sns.requestId, (err) => {
+  slack.postAlert(fixtures.slack.slackId, fixtures.slack.missingMessage, fixtures.clients.empty, fixtures.slack.channel, fixtures.sns.requestId, (err) => {
     assert.equal(err, fixtures.slack.missingMessageError, '-- should return error message');
     assert.end();
   });
 });
 
 test('[slack] [postAlert] destination user error, fallback channel success', (assert) => {
-  slack.postAlert(fixtures.slack.username, fixtures.slack.message, fixtures.clients.errorUser, fixtures.slack.channel, fixtures.sns.requestId, (err, res) => {
+  slack.postAlert(fixtures.slack.slackId, fixtures.slack.message, fixtures.clients.errorUser, fixtures.slack.channel, fixtures.sns.requestId, (err, res) => {
     assert.ifError(err, '-- should not error');
     assert.deepEqual(res, fixtures.slack.successFallback, '-- should pass through response object');
     assert.equal(res.ok, true, '-- res.ok should be true');
@@ -57,7 +57,7 @@ test('[slack] [postAlert] destination user error, fallback channel success', (as
 });
 
 test('[slack] [postAlert] destination user error, fallback channel error', (assert) => {
-  slack.postAlert(fixtures.slack.username, fixtures.slack.message, fixtures.clients.errorChannel, fixtures.slack.channel, fixtures.sns.requestId, (err, res) => {
+  slack.postAlert(fixtures.slack.slackId, fixtures.slack.message, fixtures.clients.errorChannel, fixtures.slack.channel, fixtures.sns.requestId, (err, res) => {
     assert.equal(err, fixtures.slack.errorNoChannel.error, '-- passes custom error on Slack failure');
     assert.deepEqual(res, fixtures.slack.errorNoChannel, '-- should pass through response object');
     assert.equal(res.ok, false, '-- res.ok should be false');
@@ -66,7 +66,7 @@ test('[slack] [postAlert] destination user error, fallback channel error', (asse
 });
 
 test('[slack] [postAlert] destination user success', (assert) => {
-  slack.postAlert(fixtures.slack.username, fixtures.slack.message, fixtures.clients.success, fixtures.slack.channel, fixtures.sns.requestId, (err, res) => {
+  slack.postAlert(fixtures.slack.slackId, fixtures.slack.message, fixtures.clients.success, fixtures.slack.channel, fixtures.sns.requestId, (err, res) => {
     assert.ifError(err, '-- should not error');
     assert.deepEqual(res, fixtures.slack.success, '-- should pass through response object');
     assert.equal(res.ok, true, '-- res.ok should be true');
@@ -75,7 +75,7 @@ test('[slack] [postAlert] destination user success', (assert) => {
 });
 
 test('[slack] [alertToSlack] encode error', (assert) => {
-  slack.alertToSlack(fixtures.sns.encode, fixtures.slack.username, fixtures.clients.empty, fixtures.slack.channel, (err) => {
+  slack.alertToSlack(fixtures.sns.encode, fixtures.slack.slackId, fixtures.clients.empty, fixtures.slack.channel, (err) => {
     assert.equal(err, fixtures.sns.encodeError, '-- should return error');
     assert.end();
   });
@@ -85,7 +85,7 @@ test('[slack] [alertToSlack] formatMessage error', (assert) => {
   let formatMessageStub = sinon.stub(slack, 'formatMessage') // eslint-disable-line no-unused-vars
     .yields(new TypeError('testError'));
 
-  slack.alertToSlack(fixtures.sns.malformed, fixtures.slack.username, fixtures.clients.empty, fixtures.slack.channel, (err) => {
+  slack.alertToSlack(fixtures.sns.malformed, fixtures.slack.slackId, fixtures.clients.empty, fixtures.slack.channel, (err) => {
     assert.equal(err instanceof TypeError, true, '-- should return TypeError');
     assert.end();
   });
@@ -99,7 +99,7 @@ test('[slack] [alertToSlack] postAlert error', (assert) => {
   let postAlertStub = sinon.stub(slack, 'postAlert') // eslint-disable-line no-unused-vars
     .yields(fixtures.slack.errorNoChannel.error, fixtures.slack.errorNoChannel);
 
-  slack.alertToSlack(fixtures.sns.success, fixtures.slack.username, fixtures.clients.errorUser, fixtures.slack.channel, (err) => {
+  slack.alertToSlack(fixtures.sns.success, fixtures.slack.slackId, fixtures.clients.errorUser, fixtures.slack.channel, (err) => {
     assert.equal(err, fixtures.slack.errorNoChannel, '-- should return error');
     assert.end();
   });
@@ -114,7 +114,7 @@ test('[slack] [alertToSlack] postAlert message success, no prompt', (assert) => 
   let postAlertStub = sinon.stub(slack, 'postAlert') // eslint-disable-line no-unused-vars
     .yields(null, fixtures.slack.success);
 
-  slack.alertToSlack(fixtures.sns.successNoPrompt, fixtures.slack.username, fixtures.clients.success, fixtures.slack.channel, (err, status) => {
+  slack.alertToSlack(fixtures.sns.successNoPrompt, fixtures.slack.slackId, fixtures.clients.success, fixtures.slack.channel, (err, status) => {
     assert.ifError(err, '-- should not error');
     assert.deepEqual(status, fixtures.slack.status, '-- should return status');
     assert.equal(status.alert, true, '-- status.alert should be true');
@@ -130,12 +130,12 @@ test('[slack] [alertToSlack] postAlert message success, prompt error', (assert) 
     .yields(null, fixtures.slack.message, fixtures.slack.prompt);
   let postAlertStub = sinon.stub(slack, 'postAlert');
 
-  postAlertStub.withArgs(fixtures.slack.username, fixtures.slack.message, fixtures.clients.success, fixtures.slack.channel, fixtures.sns.requestId)
+  postAlertStub.withArgs(fixtures.slack.slackId, fixtures.slack.message, fixtures.clients.success, fixtures.slack.channel, fixtures.sns.requestId)
     .yields(null, fixtures.slack.success);
-  postAlertStub.withArgs(fixtures.slack.username, fixtures.slack.prompt, fixtures.clients.success, fixtures.slack.channel, fixtures.sns.requestId)
+  postAlertStub.withArgs(fixtures.slack.slackId, fixtures.slack.prompt, fixtures.clients.success, fixtures.slack.channel, fixtures.sns.requestId)
     .yields(fixtures.slack.errorNoChannel.error, fixtures.slack.errorNoChannel);
 
-  slack.alertToSlack(fixtures.sns.success, fixtures.slack.username, fixtures.clients.success, fixtures.slack.channel, (err) => {
+  slack.alertToSlack(fixtures.sns.success, fixtures.slack.slackId, fixtures.clients.success, fixtures.slack.channel, (err) => {
     assert.equal(err, fixtures.slack.errorNoChannel.error, '-- should return error');
     assert.end();
   });
@@ -149,12 +149,12 @@ test('[slack] [alertToSlack] postAlert message success, prompt success', (assert
     .yields(null, fixtures.slack.message, fixtures.slack.prompt);
   let postAlertStub = sinon.stub(slack, 'postAlert');
 
-  postAlertStub.withArgs(fixtures.slack.username, fixtures.slack.message, fixtures.clients.success)
+  postAlertStub.withArgs(fixtures.slack.slackId, fixtures.slack.message, fixtures.clients.success)
     .yields(null, fixtures.slack.success);
-  postAlertStub.withArgs(fixtures.slack.username, fixtures.slack.prompt, fixtures.clients.success)
+  postAlertStub.withArgs(fixtures.slack.slackId, fixtures.slack.prompt, fixtures.clients.success)
     .yields(null, fixtures.slack.successPrompt);
 
-  slack.alertToSlack(fixtures.sns.success, fixtures.slack.username, fixtures.clients.success, fixtures.slack.channel, (err, status) => {
+  slack.alertToSlack(fixtures.sns.success, fixtures.slack.slackId, fixtures.clients.success, fixtures.slack.channel, (err, status) => {
     assert.ifError(err, '-- should not error');
     assert.deepEqual(status, fixtures.slack.statusPrompt, '-- should return status');
     assert.equal(status.alert, true, '-- status.alert should be true');

--- a/test/lib/slack.test.js
+++ b/test/lib/slack.test.js
@@ -58,7 +58,7 @@ test('[slack] [postAlert] destination user error, fallback channel success', (as
 
 test('[slack] [postAlert] destination user error, fallback channel error', (assert) => {
   slack.postAlert(fixtures.slack.slackId, fixtures.slack.message, fixtures.clients.errorChannel, fixtures.slack.channel, fixtures.sns.requestId, (err, res) => {
-    assert.equal(err, fixtures.slack.errorNoChannel.error, '-- passes custom error on Slack failure');
+    assert.equal(err, fixtures.slack.errorNoChannelFallback, '-- passes custom error on Slack failure');
     assert.deepEqual(res, fixtures.slack.errorNoChannel, '-- should pass through response object');
     assert.equal(res.ok, false, '-- res.ok should be false');
     assert.end();


### PR DESCRIPTION
Addressing https://github.com/mapbox/dispatch/issues/88, updates `dispatch` to use the Slack `id` rather than the soon to be deprecated `username` in API calls.