### PR TITLE
Remove URL context from broadcast logging

### DIFF
--- a/incoming/function.js
+++ b/incoming/function.js
@@ -156,7 +156,7 @@ incoming.fn = function(event, context, callback) {
               severity: 'info',
               requestId: requestId,
               service: 'lambda',
-              message: `broadcast routing success - opened GitHub issue ${status[0].url}`
+              message: 'broadcast routing success - opened GitHub issue'
             });
             return callback(null, lambdaSuccess);
           });


### PR DESCRIPTION
Exactly what it says on the box. Final output for broadcast messages does not directly aline with final output from self-service, cannot currently use identical logging call to `status[0].url`. Will circle back on this to improve.

/cc @oliikit 