### PR TITLE
Handle undefined users in low-priority

### DIFF
--- a/MESSAGE-SPEC.md
+++ b/MESSAGE-SPEC.md
@@ -143,9 +143,9 @@ Low priority dispatch messages open a GitHub issue.
   requestId: 'STRING_VALUE', // optional, ID for logging - if not passed, a 6 character random hex requestId will be generated and used
   githubRepo: 'STRING_VALUE', // optional, specify GitHub repository for Dispatch issue
   retrigger: 'BOOLEAN', // optional, defaults to true if not specified - if false Dispatch will not resend a message for a preexisting issue
-  users: [ // required
+  users: [
     {
-      github: 'STRING_VALUE' // required, GitHub handle
+      github: 'STRING_VALUE' // GitHub handle
     }
   ],
   body: { // required

--- a/MESSAGE-SPEC.md
+++ b/MESSAGE-SPEC.md
@@ -157,6 +157,8 @@ Low priority dispatch messages open a GitHub issue.
 }
 ```
 
+Only the first user of users array will be tagged in the github issue created by the low-priority message.
+
 ## Users array specification
 
 Dispatch only processes Slack IDs and GitHub handles in the `users` array. It ignores handles or usernames for other services. This allows you to connect Dispatch to a central API or username mappings file without having to scrub or remove other data.

--- a/incoming/function.js
+++ b/incoming/function.js
@@ -187,7 +187,13 @@ incoming.fn = function(event, context, callback) {
 
       // LOW-PRIORITY
       else if (message.type === 'low-priority') {
-        let user = incoming.checkUser(message.users[0], gitHubDefaultUser, slackDefaultChannel);
+        let user = undefined;
+
+        if (Array.isArray(message)) {
+          user = message.users[0];
+        }
+
+        user = incoming.checkUser(user, gitHubDefaultUser, slackDefaultChannel);
 
         incoming.callGitHub(user, message, requestId, gitHubOwner, gitHubRepo, gitHubToken, (err, res) => {
           if (err) {

--- a/test/fixtures/incoming.fixtures.js
+++ b/test/fixtures/incoming.fixtures.js
@@ -108,6 +108,27 @@ module.exports.lowPriorityEvent = {
   ]
 };
 
+module.exports.lowPriorityEventNoUser = {
+  Records:
+    [
+      { EventSource: 'aws:sns',
+        Sns: {
+          Message: JSON.stringify(
+            {
+              type: 'low-priority',
+              body: {
+                github: {
+                  title: 'testGitHubTitle',
+                  body: 'testGitHubBody'
+                }
+              }
+            }
+          )
+        }
+      }
+    ]
+};
+
 module.exports.unrecognizedEvent = {
   Records:
   [{ EventSource: 'aws:sns',

--- a/test/functions/incoming.test.js
+++ b/test/functions/incoming.test.js
@@ -195,6 +195,24 @@ test('[incoming] [fn] low-priority event', (assert) => {
   });
 });
 
+test('[incoming] [fn] low-priority event with no users', (assert) => {
+  nock('https://api.github.com')
+    .get(`/repos/${process.env.GitHubOwner}/${process.env.GitHubRepo}/issues`)
+    .query({ state: 'open', access_token: process.env.GitHubToken })
+    .reply(200, []);
+
+  nock('https://api.github.com')
+    .post(`/repos/${process.env.GitHubOwner}/${process.env.GitHubRepo}/issues`)
+    .query({ access_token: process.env.GitHubToken })
+    .reply(201, githubFixtures.lowPriorityIssue);
+
+  incoming.fn(incomingFixtures.lowPriorityEventNoUser, context, (err, res) => {
+    assert.ifError(err, '-- should not error');
+    assert.deepEqual(res, lambdaSuccess, '-- GitHub issue should be created');
+    assert.end();
+  });
+});
+
 test('[incoming] [fn] unrecognized event fallback', (assert) => {
   nock('https://api.pagerduty.com:443', { encodedQueryParams: true })
     .post('/incidents', {


### PR DESCRIPTION
This PR fixes `TypeError: Cannot read property '0' of undefined` when users in not defined in low-priority dispatch message spec.

